### PR TITLE
Add FOSS4G 2025 to list under Oceania

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 
   - 2025 IEEE International Geoscience and Remote Sensing Symposium, https://2025.ieeeigarss.org/, Brisbane, 3—8 August 2025
   - GIScience 2025, https://giscience2025.org/, Ōtautahi Christchurch, 26—29 August 2025
+  - FOSS4G 2025, Tāmaki Makaurau Auckland, November 2025
 
 ## Local
 


### PR DESCRIPTION
Announcement is at https://osgeo-oceania.org/auckland-wins-bid-to-host-the-2025-foss4g-conference. Official conference website and specific dates are not set yet, but should be sometime in November according to info in the Maptime Oceania Slack channel.

![image](https://github.com/user-attachments/assets/24bc169a-081c-4c3d-be9a-c59fc4ce4f5d)

